### PR TITLE
Handle certificate having no expiry date

### DIFF
--- a/autocert/models.py
+++ b/autocert/models.py
@@ -156,6 +156,8 @@ class Certificate(AcmeKeyModel):
             log.error('No OUTPUT_DIR specified')
 
     def certificate_expires_soon(self, days_left=30):
+        if not self.expiry_date:
+            return False
         return datetime.utcnow() + timedelta(days=days_left) > self.expiry_date
 
     def renew_and_write_if_expiring_soon(self, days_left=30):


### PR DESCRIPTION
Unissued certs cause `expiry_date` to return `None`, which `certificate_expires_soon` couldn't handle as it tried to compare it to a datetime.