### PR TITLE
Use acme's jose where present, then josepy

### DIFF
--- a/autocert/models.py
+++ b/autocert/models.py
@@ -6,7 +6,6 @@ from datetime import datetime
 from datetime import timedelta
 
 import OpenSSL
-import josepy as jose
 from acme import client as acme_client
 from acme import errors
 from django.contrib.sites.models import Site
@@ -17,6 +16,12 @@ from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.x509.oid import NameOID
+
+try:
+    from acme import jose
+except ImportError:
+    import josepy as jose
+
 
 from . import settings
 


### PR DESCRIPTION
Within jose, there is an assertion when signing the challenge that the
key is an instance of the right sort of key. This assertion fails if
autocert and acme are using different jose packages.

I think this solution should allow autocert to be compatible with more
recent versions of acme (which use josepy) and the older versions (which
include a jose package)